### PR TITLE
Fix error starting up after disk was full

### DIFF
--- a/src/gen_leader.erl
+++ b/src/gen_leader.erl
@@ -1440,7 +1440,7 @@ incarnation(VarDir, RegName, Node) ->
         {ok, Bin} = file:read_file(Name),
         binary_to_term(Bin)
     catch
-        _ ->
+        _:_ ->
             0
     end,
     ok = file:write_file(Name,term_to_binary(Incarn+1)),


### PR DESCRIPTION
We had a full disk that caused an empty file VarDir/RegName_NodeName to be created. This meant binary_to_term would fail repeatedly.

This fixes that by using an incarnation of 0 in this case.
